### PR TITLE
Fix filesystem scan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
 set(${PROJECT_NAME}_MAJOR_VERSION 02)
 set(${PROJECT_NAME}_MINOR_VERSION 02)
-set(${PROJECT_NAME}_PATCH_VERSION 01)
+set(${PROJECT_NAME}_PATCH_VERSION 02)
 
 include(cmake/set_version_numbers.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/set_default_flags.cmake)

--- a/src/WatchdogServer.cc
+++ b/src/WatchdogServer.cc
@@ -29,7 +29,7 @@ std::set<std::pair<std::string, std::string>> findMountPoints() {
   while(in.good()) {
     in >> strin[0] >> strin[1] >> strin[2] >> strin[3] >> iin[0] >> iin[1];
     bfs::path p(strin[0]);
-    if(strin[0].substr(0, 7).compare("/dev/sd") == 0) {
+    if(strin[0].substr(0, 7).compare("/dev/sd") == 0 || strin[0].substr(0, 8).compare("/dev/mmc")) {
       if(strin[1].substr(0, 6).compare("/boot/") != 0) {
         out.insert(std::make_pair(p.filename().string(), strin[1]));
       }


### PR DESCRIPTION
On raspberry pi file systems the root partition is not found.
So far we only scan for devices like `dev/sd`.